### PR TITLE
Add support for RTMPS streaming

### DIFF
--- a/Source/Rtmp/RTMPSession.swift
+++ b/Source/Rtmp/RTMPSession.swift
@@ -336,7 +336,7 @@ extension RTMPSession {
                     } else {
                         // Type 0.
                         put_byte(&chunk, val: chunkStreamId.rawValue & 0x1F)
-                        put_be24(&chunk, val: Int32(ts))
+                        put_be24(&chunk, val: Int32(ts & UInt64(Int32.max)))
                         put_be24(&chunk, val: Int32(metaData.msgLength))
                         put_byte(&chunk, val: metaData.msgTypeId.rawValue)
                         // msg stream id is little-endian

--- a/Source/Rtmp/RTMPSession.swift
+++ b/Source/Rtmp/RTMPSession.swift
@@ -294,6 +294,7 @@ extension RTMPSession {
         reset()
         let port = uri.port ?? 1935
         Logger.info("Connecting:\(host):\(port), stream name:\(playPath)")
+        streamSession.negotiateSSL = (uri.scheme?.lowercased() == "rtmps")
         streamSession.connect(host: host, port: port, sscb: { [weak self] (_, status) in
             self?.streamStatusChanged(status)
         })

--- a/Source/Stream/IStreamSession.swift
+++ b/Source/Stream/IStreamSession.swift
@@ -24,8 +24,9 @@ public struct StreamStatus: OptionSet {
 
 public typealias StreamSessionCallback = (IStreamSession, StreamStatus) -> Void
 
-public protocol IStreamSession {
+public protocol IStreamSession: class {
     var status: StreamStatus { get }
+    var negotiateSSL: Bool { get set }
 
     func connect(host: String, port: Int, sscb callback: @escaping StreamSessionCallback)
     func disconnect()

--- a/Source/Stream/StreamSession.swift
+++ b/Source/Stream/StreamSession.swift
@@ -18,6 +18,7 @@ class StreamCallback: NSObject, StreamDelegate {
 
 open class StreamSession: IStreamSession {
     open var status: StreamStatus = .init()
+    open var negotiateSSL = false
 
     private var inputStream: InputStream?
     private var outputStream: OutputStream?
@@ -169,6 +170,12 @@ open class StreamSession: IStreamSession {
         inputStream?.schedule(in: runLoop, forMode: .defaultRunLoopMode)
         outputStream?.delegate = streamCallback
         outputStream?.schedule(in: runLoop, forMode: .defaultRunLoopMode)
+        if negotiateSSL {
+            inputStream?.setProperty(StreamSocketSecurityLevel.negotiatedSSL,
+                                     forKey: .socketSecurityLevelKey)
+            outputStream?.setProperty(StreamSocketSecurityLevel.negotiatedSSL,
+                                     forKey: .socketSecurityLevelKey)
+        }
         outputStream?.open()
         inputStream?.open()
 


### PR DESCRIPTION
Facebook requires streams to be in RTMPS format since May 1. This PR adds support for SSL negotiation when scheme is rtmps://

I also fixed a runtime crash when timestamp value did not fit within Int32.